### PR TITLE
Fix some miss typed compiler flags

### DIFF
--- a/compiler-flags-options.org
+++ b/compiler-flags-options.org
@@ -49,7 +49,7 @@
      + Enables extra flags not enabled by -Wall, such as
        -Wsign-compare (C only), -Wtype-limits, -Wuninitialized ...
 
-   + -pendantic or -Wpendantic
+   + -pedantic or -Wpedantic
      + Issue all warning required by ISO C and ISO C++ standard, it
        issues warning whenever there are compiler extensions non
        compliant to ISO C or C++ standard.
@@ -84,7 +84,7 @@
    + -O3
      + Higher level of optmization. Slower compile-time, better for
        production builds.
-   + -OFast
+   + -Ofast
      + Enables higher level of optmization than (-O3). It enables lots
        of flags as can be seen [[https://stackoverflow.com/questions/3005564/gcc-options-for-fastest-code][src]] (-ffloat-store, -ffsast-math,
        -ffinite-math-only, -O3 ...)


### PR DESCRIPTION
Fixed some compiler flags that were misstyped like `-pedantic, -Wpedantic and -Ofast`

